### PR TITLE
fix(sponsors): allow sharp build script in pnpm install

### DIFF
--- a/sponsors/pnpm-workspace.yaml
+++ b/sponsors/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+allowBuilds:
+  sharp: true


### PR DESCRIPTION
## Problem

The [Sponsors Updater](https://github.com/kashalls/kashalls/actions/runs/27079062726) workflow fails on the `npx pnpm i` step:

```
[ERR_PNPM_IGNORED_BUILDS] Ignored build scripts: sharp@0.34.5
Run "pnpm approve-builds" to pick which dependencies should be allowed to run scripts.
##[error]Process completed with exit code 1.
```

`npx pnpm` now resolves to pnpm 11, which blocks dependency build scripts by default as a supply-chain protection and **exits non-zero** when builds are ignored. `sharp` (a transitive dep of `sponsorkit`) has a build script, so the install fails.

## Fix

Approve `sharp`'s build script via `sponsors/pnpm-workspace.yaml` — the new home for this setting in pnpm 11 (the `pnpm` field in `package.json` is no longer read).

Verified locally with `pnpm@11.5.2`: `pnpm i` now builds sharp and exits 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)